### PR TITLE
Create padel match management app

### DIFF
--- a/padel-app/app.js
+++ b/padel-app/app.js
@@ -1,0 +1,64 @@
+const courts = JSON.parse(localStorage.getItem('courts') || '[]');
+const matches = JSON.parse(localStorage.getItem('matches') || '[]');
+
+const courtForm = document.getElementById('court-form');
+const courtList = document.getElementById('court-list');
+const matchForm = document.getElementById('match-form');
+const matchList = document.getElementById('match-list');
+const matchCourtSelect = document.getElementById('match-court');
+
+function saveData() {
+    localStorage.setItem('courts', JSON.stringify(courts));
+    localStorage.setItem('matches', JSON.stringify(matches));
+}
+
+function renderCourts() {
+    courtList.innerHTML = '';
+    matchCourtSelect.innerHTML = '';
+    courts.forEach((court, index) => {
+        const li = document.createElement('li');
+        li.textContent = court.name + ' - ' + court.location;
+        courtList.appendChild(li);
+
+        const option = document.createElement('option');
+        option.value = index;
+        option.textContent = court.name;
+        matchCourtSelect.appendChild(option);
+    });
+}
+
+function renderMatches() {
+    matchList.innerHTML = '';
+    matches.forEach(match => {
+        const li = document.createElement('li');
+        const court = courts[match.court];
+        li.textContent = `${match.date} - ${match.player1} vs ${match.player2} @ ${court ? court.name : 'Pista'}`;
+        matchList.appendChild(li);
+    });
+}
+
+courtForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const name = document.getElementById('court-name').value;
+    const location = document.getElementById('court-location').value;
+    courts.push({ name, location });
+    saveData();
+    renderCourts();
+    courtForm.reset();
+});
+
+matchForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const player1 = document.getElementById('player1').value;
+    const player2 = document.getElementById('player2').value;
+    const date = document.getElementById('match-date').value;
+    const courtIndex = matchCourtSelect.value;
+    matches.push({ player1, player2, date, court: courtIndex });
+    saveData();
+    renderMatches();
+    matchForm.reset();
+});
+
+// Initial render
+renderCourts();
+renderMatches();

--- a/padel-app/index.html
+++ b/padel-app/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestor de Pádel</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Gestión de Partidos y Pistas de Pádel</h1>
+    </header>
+
+    <section id="court-section">
+        <h2>Añadir Pista</h2>
+        <form id="court-form">
+            <input type="text" id="court-name" placeholder="Nombre de la pista" required>
+            <input type="text" id="court-location" placeholder="Ubicación" required>
+            <button type="submit">Añadir Pista</button>
+        </form>
+        <ul id="court-list"></ul>
+    </section>
+
+    <section id="match-section">
+        <h2>Añadir Partido</h2>
+        <form id="match-form">
+            <input type="text" id="player1" placeholder="Jugador 1" required>
+            <input type="text" id="player2" placeholder="Jugador 2" required>
+            <input type="datetime-local" id="match-date" required>
+            <select id="match-court" required></select>
+            <button type="submit">Añadir Partido</button>
+        </form>
+        <ul id="match-list"></ul>
+    </section>
+
+    <footer>
+        <p>Padel Manager</p>
+    </footer>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/padel-app/style.css
+++ b/padel-app/style.css
@@ -1,0 +1,67 @@
+:root {
+    --primary-color: #005fa3;
+    --secondary-color: #f0f8ff;
+}
+
+body {
+    font-family: "Segoe UI", Arial, sans-serif;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 1rem;
+    min-height: 100vh;
+    background-color: var(--primary-color);
+    color: #fff;
+}
+
+h1 {
+    text-align: center;
+    color: #fff;
+}
+
+header, footer {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+footer {
+    color: #fff;
+    font-size: 0.9rem;
+}
+
+section {
+    margin-bottom: 2rem;
+    background: #fff;
+    color: #333;
+    padding: 1rem;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+form input, form select, form button {
+    margin: 0.5rem 0;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+li {
+    padding: 0.5rem;
+    border-bottom: 1px solid #ccc;
+}
+
+button {
+    background-color: var(--primary-color);
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #00447a;
+}


### PR DESCRIPTION
## Summary
- add a small web app under `padel-app/` to manage padel courts and matches
- restyle the interface with a blue theme and simple header/footer

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_683fe7ad61d883329fe724691e6d2b39